### PR TITLE
Normalize RestDB base URL when building API client

### DIFF
--- a/app.js
+++ b/app.js
@@ -249,7 +249,7 @@
   const LinksAPI = DEMO_MODE ? LocalLinksAPI() : RestDBLinksAPI(cfg);
 
   function RestDBLinksAPI(cfg) {
-    const base = cfg.baseUrl.replace(/\/$/, "");
+    const base = normalizeRestBase(cfg.baseUrl);
     const coll = (cfg.collections && cfg.collections.links) || "links";
     const headers = {
       "content-type": "application/json",
@@ -274,6 +274,13 @@
         return res.json();
       }
     };
+  }
+
+  function normalizeRestBase(url) {
+    if (!url) return "";
+    const trimmed = url.replace(/\/$/, "");
+    if (/\/rest$/i.test(trimmed)) return trimmed;
+    return `${trimmed}/rest`;
   }
 
   function LocalLinksAPI() {


### PR DESCRIPTION
## Summary
- ensure the RestDB client normalizes the configured base URL to include the required `/rest` suffix
- avoid cross-origin preflight failures triggered by calling the wrong RestDB endpoint

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e2ccd39234832dae5a826074efe4a1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved REST API URL handling to prevent broken requests caused by trailing slashes or missing “/rest” in the base URL.
  - Enhanced compatibility with varied base URL formats (including empty or case-insensitive inputs), reducing 404s and connection issues.
  - More reliable link fetching in the REST data source without changes to behavior elsewhere.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->